### PR TITLE
Couple fixes in lock-thread.js

### DIFF
--- a/buttons/brew/lock-thread.js
+++ b/buttons/brew/lock-thread.js
@@ -1,20 +1,37 @@
+const { Permissions } = require('discord.js');
+
 module.exports = {
   data: {
     name: `lock-thread`
   },
   async execute(interaction, client) {
-    const thread = await client.channels.fetch(interaction.channel.id);
-    const threadMessages = await thread.messages.fetch({ after: 1, limit: 1 });
-    const message = threadMessages.first();
-    const brewer = message.mentions.users.first();
+    try
+    {
+      const thread = await client.channels.fetch(interaction.channel.id);
+      if(!thread.isThread()){
+        await interaction.editReply({content: 'Something went wrong.', ephemeral: true});
+        return;
+      }
 
-    if (!thread.archived && interaction.user === brewer) {
-      await interaction.reply(`This thread was locked by ${interaction.user}.`);
-      if (!thread.locked) { await thread.setLocked(true); }
-      await thread.setArchived(true);
-      return;
-    } else {
-      await interaction.reply({ content: `Only ${brewer} or an admin can lock this thread.`, ephemeral: true });
+      const threadMessages = await thread.messages.fetch({ after: 1, limit: 1 });
+      const message = threadMessages.first();
+      const brewer = message.mentions.users.first();
+  
+      const isThreadActive = !thread.archived;
+      const isUserBrewer = interaction.user === brewer;
+      const isUserAdmin = interaction.member.permissions.has(Permissions.FLAGS.ADMINISTRATOR);
+      
+      if (isThreadActive && (isUserBrewer || isUserAdmin)) {
+        await interaction.reply(`This thread was locked by ${interaction.user}.`);
+        if (!thread.locked) { await thread.setLocked(true); }
+        await thread.setArchived(true);
+        return;
+      } else {
+        await interaction.reply({ content: `Only ${brewer} or an admin can lock this thread.`, ephemeral: true });
+      }
+    } catch(error)
+    {
+      console.log(error);
     }
   }
 }


### PR DESCRIPTION
added ability for channel admin to use lock-thread button. added check for edge case of non-thread button. Wrapped execute function in try/catch to prevent bot crashes.

Note: I'll defer to you if we should just not worry about this button being accidentally added to a channel instead of a thread. While playing around with it I noticed that doing so would crash the bot.