### PR TITLE
remove wishlist command user's other wishlist posts when called

### DIFF
--- a/commands/user/wishlist.js
+++ b/commands/user/wishlist.js
@@ -37,6 +37,11 @@ module.exports = {
       return;
     } else {
       const channel = await client.channels.fetch(guildObject.wishlist_channel);
+      const messages = await channel.messages.fetch({limit: 100});
+      const filteredMessages = messages
+                                .filter(m => m.author === client.user)
+                                .filter(m => m.embeds[0].description.includes(`<@${interaction.user.id}>`));
+      filteredMessages.each(m => m.delete());
       await channel.send({ embeds: [embed] });
       await interaction.reply({ content: `Your wishlist has been added to the ${channel} channel.`, ephemeral: true });
     }


### PR DESCRIPTION
My attempt at #4 

May not be super efficient on larger servers. Seems that there is a limit to the # of messages that you can fetch ( 100 ).
May need to recommend storing the message id of the users's last wishlist post. ( That is: The id of the message that the bot will put in the channel ).